### PR TITLE
Fix "get_clipboard" platform checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ get_clipboard
 
 **Keyword Arguments:** None.
 
-**Returns:** Tuple, `clipboard_copy()` and `clipboard_paste()`.
+**Returns:** NamedTuple, `clipboard_copy()` and `clipboard_paste()`.
 
 **Source Code file:** https://github.com/juancarlospaco/anglerfish/blob/master/anglerfish/get_clipboard.py
 
@@ -243,6 +243,10 @@ from anglerfish import get_clipboard
 clipboard_copy, clipboard_paste = get_clipboard()
 clipboard_copy("This is a Test.")
 print(clipboard_paste())
+
+# Or this way:
+get_clipboard().copy("This is a Test.")
+print(get_clipboard().paste())
 ```
 </details>
 

--- a/anglerfish/get_clipboard.py
+++ b/anglerfish/get_clipboard.py
@@ -69,7 +69,7 @@ def __determine_clipboard():
     """Determine OS and set copy() and paste() functions accordingly."""
     if sys.platform.startswith("darwin"):
         return __osx_clipboard()
-    if sys.platform.startswith("windows"):
+    elif sys.platform.startswith("win"):
         try:  # Determine which command/module is installed, if any.
             import win32clipboard  # lint:ok noqa
         except ImportError:
@@ -77,7 +77,7 @@ def __determine_clipboard():
             return None, None  # install Win32.
         else:
             return __win32_clibboard()
-    if sys.platform.startswith("linux") and which("xclip"):
+    elif sys.platform.startswith("linux") and which("xclip"):
         return __xclip_clipboard()
     else:
         log.error("Install XClip and XSel Linux Packages at least.")

--- a/anglerfish/get_clipboard.py
+++ b/anglerfish/get_clipboard.py
@@ -12,6 +12,9 @@ import logging as log
 
 from shutil import which
 
+from collections import namedtuple
+
+Clipboard = namedtuple('Clipboard', 'copy paste')
 
 def __osx_clipboard():
     def copy_osx(text):
@@ -90,4 +93,4 @@ def get_clipboard():
     global clipboard_copy, clipboard_paste
     clipboard_copy, clipboard_paste = None, None
     clipboard_copy, clipboard_paste = __determine_clipboard()
-    return clipboard_copy, clipboard_paste
+    return Clipboard(clipboard_copy, clipboard_paste)


### PR DESCRIPTION
- For function "get_clipbboard", the "sys.platform" checking for Windows is NOT "windows" but "win32". Please refer to [sys.platform](https://docs.python.org/3/library/sys.html#sys.platform).
- By the way, I used NamedTuple for the returns. I think this get a better accessibility (and it does not break the existing API). Will cancel it if you don't like.